### PR TITLE
.github/dependabot.yml: Restrict dependabot to update approved GitHub…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,23 @@
 version: 2
 updates:
-  # Automatically propose PRs for out-of-date GitHub actions
-  # - package-ecosystem: github-actions
-  #   directory: "/"
-  #   schedule:
-  #     # Check for new versions weekly
-  #     interval: weekly
-  #   # Update all actions in a single PR
-  #   groups:
-  #     github-actions:
-  #       patterns: ["*"]
-  #   labels:
-  #     - automation
-  #     - gha-update
+updates:
+  # Using dependabot for all GHA violates pinning policy
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      # Check for new versions weekly
+      interval: weekly
+    # Update all actions in a single PR
+    groups:
+      github-actions:
+        patterns: ["*"]
+    labels:
+      - automation
+      - gha-update
+    # Only allow updates for actions maintained by GitHub
+    allow:
+      - dependency-name: "actions/*"
+      - dependency-name: "github-actions/*"
 
   # Automatically propose PRs for Python dependencies
   - package-ecosystem: pip


### PR DESCRIPTION
… actions

Restrict dependabot to only apply automatic updates to GitHub actions that come from GitHub themselves (`actions/*`) and our own action (`azimuth-cloud/github-actions`).